### PR TITLE
some security fixes

### DIFF
--- a/zabbix/1.6.9/zabbix-1.6.9-fix_CVE-2011-3263_DoS_attack.patch
+++ b/zabbix/1.6.9/zabbix-1.6.9-fix_CVE-2011-3263_DoS_attack.patch
@@ -1,0 +1,173 @@
+diff -uNrp zabbix-1.6.9.orig//src/libs/zbxsysinfo/common/file.c zabbix-1.6.9//src/libs/zbxsysinfo/common/file.c
+--- zabbix-1.6.9.orig//src/libs/zbxsysinfo/common/file.c	2010-03-25 23:53:19.000000000 +0900
++++ zabbix-1.6.9//src/libs/zbxsysinfo/common/file.c	2011-11-02 13:24:30.000000000 +0900
+@@ -25,6 +25,8 @@
+ 
+ #include "file.h"
+ 
++extern int     CONFIG_TIMEOUT;
++
+ int	VFS_FILE_SIZE(const char *cmd, const char *param, unsigned flags, AGENT_RESULT *result)
+ {
+ 	struct stat	buf;
+@@ -135,12 +137,13 @@ int	VFS_FILE_REGEXP(const char *cmd, con
+ 	int	len;
+ 	char	tmp[MAX_STRING_LEN];
+ 	char	*c;
+-
+ 	char	*buf = NULL;
++	double  ts;
+ 
+         assert(result);
+ 
+         init_result(result);
++	ts = zbx_time();
+ 
+ 	memset(tmp,0,MAX_STRING_LEN);
+ 
+@@ -154,7 +157,6 @@ int	VFS_FILE_REGEXP(const char *cmd, con
+ 		return SYSINFO_RET_FAIL;
+ 	}
+ 
+-
+ 	if(NULL == (f = fopen(filename,"r")))
+ 	{
+ 		return SYSINFO_RET_FAIL;
+@@ -165,6 +167,11 @@ int	VFS_FILE_REGEXP(const char *cmd, con
+ 		goto lbl_fail;
+ 	}
+ 
++	if (CONFIG_TIMEOUT < zbx_time() - ts)
++	{
++		goto lbl_fail;
++	}
++
+ 	if(0 == fread(buf, 1, MAX_FILE_LEN-1, f))
+ 	{
+ 		goto lbl_fail;
+@@ -205,12 +212,13 @@ int	VFS_FILE_REGMATCH(const char *cmd, c
+ 	FILE	*f = NULL;
+ 	int	len;
+ 	char	*c;
+-
+ 	char	*buf = NULL;
++	double  ts;
+ 
+         assert(result);
+ 
+         init_result(result);
++	ts = zbx_time();
+ 
+ 	if(get_param(param, 1, filename, MAX_STRING_LEN) != 0)
+ 	{
+@@ -222,7 +230,6 @@ int	VFS_FILE_REGMATCH(const char *cmd, c
+ 		return SYSINFO_RET_FAIL;
+ 	}
+ 
+-
+ 	if(NULL == (f = fopen(filename,"r")))
+ 	{
+ 		return SYSINFO_RET_FAIL;
+@@ -233,6 +240,11 @@ int	VFS_FILE_REGMATCH(const char *cmd, c
+ 		goto lbl_fail;
+ 	}
+ 
++	if (CONFIG_TIMEOUT < zbx_time() - ts)
++	{
++		goto lbl_fail;
++	}
++
+ 	if(0 == fread(buf, 1, MAX_FILE_LEN-1, f))
+ 	{
+ 		goto lbl_fail;
+@@ -280,10 +292,12 @@ int	VFS_FILE_MD5SUM(const char *cmd, con
+ 	md5_byte_t	hash[MD5_DIGEST_SIZE];
+ 
+ 	char filename[MAX_STRING_LEN];
++	double		ts;
+ 	
+ 	assert(result);
+ 	
+         init_result(result);	
++	ts = zbx_time();
+ 
+         if(num_param(param) > 1)
+         {
+@@ -312,9 +326,19 @@ int	VFS_FILE_MD5SUM(const char *cmd, con
+ 		return	SYSINFO_RET_FAIL;
+ 	}
+ 
++	if (CONFIG_TIMEOUT < zbx_time() - ts)
++	{
++		goto lbl_fail;
++	}
++
+         md5_init(&state);
+ 	while ((nr = fread(buf, 1, (size_t)sizeof(buf), file)) > 0)
+ 	{
++		if (CONFIG_TIMEOUT < zbx_time() - ts)
++		{
++			goto lbl_fail;
++		}
++
+         	md5_append(&state,(const md5_byte_t *)buf, (int)nr);
+ 	}
+         md5_finish(&state, hash);
+@@ -331,6 +355,11 @@ int	VFS_FILE_MD5SUM(const char *cmd, con
+ 
+ 	return SYSINFO_RET_OK;
+ 
++lbl_fail:
++
++	zbx_fclose(file);
++
++	return	SYSINFO_RET_FAIL;
+ }
+ 
+ /* Code for cksum is based on code from cksum.c */
+@@ -412,10 +441,12 @@ int	VFS_FILE_CKSUM(const char *cmd, cons
+ 	u_long cval, clen;
+ 	FILE	*f;
+ 	char	filename[MAX_STRING_LEN];
++	double		ts;
+ 
+ 	assert(result);
+ 
+         init_result(result);	
++	ts = zbx_time();
+ 
+ 	if(num_param(param) > 1)
+         {
+@@ -432,11 +463,21 @@ int	VFS_FILE_CKSUM(const char *cmd, cons
+ 		return	SYSINFO_RET_FAIL;
+ 	}
+ 
++	if (CONFIG_TIMEOUT < zbx_time() - ts)
++	{
++		goto lbl_fail;
++	}
++
+ #define	COMPUTE(var, ch)	(var) = (var) << 8 ^ crctab[(var) >> 24 ^ (ch)]
+ 
+ 	crc = len = 0;
+ 	while ((nr = (int)fread(buf, 1, sizeof(buf), f)) > 0)
+ 	{
++		if (CONFIG_TIMEOUT < zbx_time() - ts)
++		{
++			goto lbl_fail;
++		}
++
+ 		for( len += nr, p = buf; nr--; ++p)
+ 		{
+ 			COMPUTE(crc, *p);
+@@ -461,4 +502,10 @@ int	VFS_FILE_CKSUM(const char *cmd, cons
+ 	SET_UI64_RESULT(result, cval);
+ 
+ 	return	SYSINFO_RET_OK;
++
++lbl_fail:
++
++	zbx_fclose(f);
++
++	return	SYSINFO_RET_FAIL;
+ }

--- a/zabbix/1.6.9/zabbix-1.6.9-fix_CVE-2011-3264_path_disclosure.patch
+++ b/zabbix/1.6.9/zabbix-1.6.9-fix_CVE-2011-3264_path_disclosure.patch
@@ -1,0 +1,20 @@
+diff -uNrp zabbix-1.6.9.orig/frontends/php/include/config.inc.php zabbix-1.6.9/frontends/php/include/config.inc.php
+--- zabbix-1.6.9.orig/frontends/php/include/config.inc.php	2010-03-25 23:53:21.000000000 +0900
++++ zabbix-1.6.9/frontends/php/include/config.inc.php	2011-10-27 11:54:13.000000000 +0900
+@@ -85,9 +85,13 @@ function TODO($msg) { echo "TODO: ".$msg
+ 	require_once 	'include/validate.inc.php';
+ 
+ 	function zbx_err_handler($errno, $errstr, $errfile, $errline){
+-		error($errstr.'['.$errfile.':'.$errline.']');
+-//		show_messages();
+-//		die();
++		$pathLength = strlen(__FILE__);
++
++		// strlen(include/config.inc.php) = 22
++		$pathLength -= 22;
++		$errfile = substr($errfile, $pathLength);
++
++		error($errstr.' ['.$errfile.':'.$errline.']');
+ 	}
+ 
+ 	/********** START INITIALIZATION *********/

--- a/zabbix/1.6.9/zabbix.spec
+++ b/zabbix/1.6.9/zabbix.spec
@@ -1,6 +1,6 @@
 Name:           zabbix
 Version:        1.6.9
-Release:        3%{?dist}
+Release:        5%{?dist}
 Summary:        Open-source monitoring solution for your IT infrastructure
 
 Group:          Applications/Internet
@@ -45,6 +45,8 @@ Patch29:        zabbix-1.6.9-graphview_over372day.patch
 Patch30:        zabbix-1.6.9-sending_each_alert_for_logmonitoring.patch
 Patch31:        zabbix-1.6.9-default_period.patch
 Patch32:        zabbix-1.6.9-fix_timer_process.patch
+Patch33:        zabbix-1.6.9-fix_CVE-2011-3263_DoS_attack.patch
+Patch34:        zabbix-1.6.9-fix_CVE-2011-3264_path_disclosure.patch
 
 Buildroot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -282,6 +284,8 @@ Zabbix web frontend for SQLite
 %patch30 -p1 -b .sending_each_alert_for_logmonitoring.orig
 %patch31 -p1 -b .default_period.orig
 %patch32 -p1 -b .fix_timer_process.orig
+%patch33 -p1 -b .fix_CVE-2011-3263_DoS_attack.orig
+%patch34 -p1 -b .fix_CVE-2011-3264_path_disclosure.orig
 
 rm frontends/php/include/locales/ja_jp.inc.php
 cp %{SOURCE6} frontends/php/include/locales/ja_jp.inc.php
@@ -601,6 +605,10 @@ fi
 %defattr(-,root,root,-)
 
 %changelog
+* Sun Nov 13 2011 Takanori Suzuki <mail.tks@gmail.com> - 1.6.9-5
+- Fix zabbix_agentd DoS attack issue (ZBX-3794) (CVE-2011-3263) (Patch33)
+- Fix path disclosure vulnerability (ZBX-3840) (CVE-2011-3264) (Patch34)
+
 * Wed Dec 29 2010 Kodai Terashima <kodai74@gmail.com> - 1.6.9-4
 - Add requires fonts-japanese and ttfonts-ja to zabbix-web package
 


### PR DESCRIPTION
- Fix zabbix_agentd DoS attack issue (ZBX-3794) (CVE-2011-3263)
- Fix path disclosure vulnerability (ZBX-3840) (CVE-2011-3264)
- XSS issue (CVE-2011-2904) is also checked, but it doesn't affect 1.6.9
